### PR TITLE
package.json debug dependency is vulnerable

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "content-type": "~1.0.4",
     "cookie": "0.3.1",
     "cookie-signature": "1.0.6",
-    "debug": "2.6.9",
+    "debug": ">=2.6.9 < 3.0.0 || >= 3.1.0",
     "depd": "~1.1.2",
     "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",


### PR DESCRIPTION
package.json dependency "debug": "2.6.9"  -> "debug": ">=2.6.9 < 3.0.0 || >= 3.1.0"
security vulnerability, updating the package.json with a patched version of debug